### PR TITLE
feat: Qiita記事アプリに機能追加と不具合修正

### DIFF
--- a/qiita-ai/src/constants/tags.ts
+++ b/qiita-ai/src/constants/tags.ts
@@ -28,4 +28,5 @@ export const ZENN_TOPIC_MAP: Record<string, string> = {
 }
 
 // Default Zenn topics to fetch when no tags are selected
-export const DEFAULT_ZENN_TOPICS = ['llm', 'ai', 'chatgpt', 'generativeai', 'rag']
+// Default Zenn topics — limited to 3 to reduce API requests and speed up loading
+export const DEFAULT_ZENN_TOPICS = ['llm', 'ai', 'chatgpt']

--- a/qiita-ai/src/hooks/useArticles.ts
+++ b/qiita-ai/src/hooks/useArticles.ts
@@ -25,7 +25,17 @@ type State = UseArticlesResult
 type Action =
   | { type: 'loading' }
   | { type: 'success'; articles: Article[]; totalCount: number }
+  | { type: 'partial'; articles: Article[]; totalCount: number }
+  | { type: 'append'; articles: Article[]; sort: SortOrder }
   | { type: 'error'; message: string }
+
+function sortArticles(articles: Article[], sort: SortOrder): Article[] {
+  return [...articles].sort((a, b) =>
+    sort === 'likes'
+      ? b.likes_count - a.likes_count
+      : new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  )
+}
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -33,6 +43,12 @@ function reducer(state: State, action: Action): State {
       return { ...state, loading: true, error: null }
     case 'success':
       return { articles: action.articles, totalCount: action.totalCount, loading: false, error: null }
+    case 'partial':
+      return { articles: action.articles, totalCount: action.totalCount, loading: false, error: null }
+    case 'append': {
+      const merged = sortArticles([...state.articles, ...action.articles], action.sort)
+      return { ...state, articles: merged }
+    }
     case 'error':
       return { ...state, loading: false, error: action.message }
   }
@@ -50,53 +66,52 @@ export function useArticles({ tags, sort, page, source, dateRange, retryCount = 
 
     dispatch({ type: 'loading' })
 
-    async function load(): Promise<{ articles: Article[]; totalCount: number }> {
-      if (source === 'qiita') {
-        return fetchQiitaArticles({ tags, sort, page, dateRange })
-      }
+    if (source === 'qiita') {
+      fetchQiitaArticles({ tags, sort, page, dateRange })
+        .then(({ articles, totalCount }) => {
+          if (!cancelled) dispatch({ type: 'success', articles, totalCount })
+        })
+        .catch((err: Error) => {
+          if (!cancelled) dispatch({ type: 'error', message: err.message })
+        })
+    } else if (source === 'zenn') {
+      fetchZennArticles({ tags, sort, page })
+        .then(({ articles, totalCount }) => {
+          if (!cancelled) dispatch({ type: 'success', articles, totalCount })
+        })
+        .catch((err: Error) => {
+          if (!cancelled) dispatch({ type: 'error', message: err.message })
+        })
+    } else {
+      // 'all': Qiitaを先に表示、Zennを後から追加（段階的フェッチ）
+      let qiitaFailed = false
+      let zennFailed = false
 
-      if (source === 'zenn') {
-        return fetchZennArticles({ tags, sort, page })
-      }
+      const qiitaPromise = fetchQiitaArticles({ tags, sort, page, dateRange })
+        .then(({ articles, totalCount }) => {
+          if (!cancelled) dispatch({ type: 'partial', articles, totalCount })
+        })
+        .catch((err: Error) => {
+          qiitaFailed = true
+          return err
+        })
 
-      // 'all': fetch both in parallel, merge results
-      const [qiitaResult, zennResult] = await Promise.allSettled([
-        fetchQiitaArticles({ tags, sort, page, dateRange }),
-        fetchZennArticles({ tags, sort, page }),
-      ])
+      const zennPromise = fetchZennArticles({ tags, sort, page })
+        .then(({ articles }) => {
+          if (!cancelled) dispatch({ type: 'append', articles, sort })
+        })
+        .catch((err: Error) => {
+          zennFailed = true
+          return err
+        })
 
-      if (qiitaResult.status === 'rejected' && zennResult.status === 'rejected') {
-        throw (qiitaResult.reason as Error)
-      }
-
-      const qiita =
-        qiitaResult.status === 'fulfilled'
-          ? qiitaResult.value
-          : { articles: [], totalCount: 0 }
-      const zenn =
-        zennResult.status === 'fulfilled'
-          ? zennResult.value
-          : { articles: [], totalCount: 0 }
-
-      const merged = [...qiita.articles, ...zenn.articles]
-      if (sort === 'likes') {
-        merged.sort((a, b) => b.likes_count - a.likes_count)
-      } else {
-        merged.sort(
-          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-        )
-      }
-
-      return { articles: merged, totalCount: qiita.totalCount }
+      Promise.all([qiitaPromise, zennPromise]).then(([qiitaErr]) => {
+        if (!cancelled && qiitaFailed && zennFailed) {
+          const msg = qiitaErr instanceof Error ? qiitaErr.message : '記事の取得に失敗しました'
+          dispatch({ type: 'error', message: msg })
+        }
+      })
     }
-
-    load()
-      .then(({ articles, totalCount }) => {
-        if (!cancelled) dispatch({ type: 'success', articles, totalCount })
-      })
-      .catch((err: Error) => {
-        if (!cancelled) dispatch({ type: 'error', message: err.message })
-      })
 
     return () => {
       cancelled = true

--- a/qiita-ai/src/hooks/useFavorites.ts
+++ b/qiita-ai/src/hooks/useFavorites.ts
@@ -1,23 +1,46 @@
-import { useState, useCallback } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 import type { Article } from '../types/article'
 import type { FavoriteArticle } from '../types/kanban'
 import { FAVORITES_STORAGE_KEY } from '../types/kanban'
+import { loadJson, saveJson } from '../utils/storage'
 
-function loadFavorites(): FavoriteArticle[] {
-  try {
-    const raw = localStorage.getItem(FAVORITES_STORAGE_KEY)
-    return raw ? (JSON.parse(raw) as FavoriteArticle[]) : []
-  } catch {
-    return []
+type Listener = () => void
+
+let cache: FavoriteArticle[] | null = null
+const listeners = new Set<Listener>()
+
+function getSnapshot(): FavoriteArticle[] {
+  if (cache === null) {
+    cache = loadJson<FavoriteArticle[]>(FAVORITES_STORAGE_KEY, [])
+  }
+  return cache
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener)
+
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === FAVORITES_STORAGE_KEY) {
+      cache = null
+      listeners.forEach((l) => l())
+    }
+  }
+  window.addEventListener('storage', onStorage)
+
+  return () => {
+    listeners.delete(listener)
+    window.removeEventListener('storage', onStorage)
   }
 }
 
-function saveFavorites(favorites: FavoriteArticle[]): void {
-  localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify(favorites))
+function setFavorites(next: FavoriteArticle[]): void {
+  saveJson(FAVORITES_STORAGE_KEY, next)
+  cache = next
+  listeners.forEach((l) => l())
 }
 
 export function useFavorites() {
-  const [favorites, setFavorites] = useState<FavoriteArticle[]>(loadFavorites)
+  const favorites = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 
   const isFavorite = useCallback(
     (articleId: string) => favorites.some((f) => f.id === articleId),
@@ -26,24 +49,19 @@ export function useFavorites() {
 
   const toggleFavorite = useCallback(
     (article: Article) => {
-      setFavorites((prev) => {
-        const exists = prev.some((f) => f.id === article.id)
-        const next = exists
-          ? prev.filter((f) => f.id !== article.id)
-          : [...prev, { ...article, favorited_at: new Date().toISOString() }]
-        saveFavorites(next)
-        return next
-      })
+      const current = getSnapshot()
+      const exists = current.some((f) => f.id === article.id)
+      const next = exists
+        ? current.filter((f) => f.id !== article.id)
+        : [...current, { ...article, favorited_at: new Date().toISOString() }]
+      setFavorites(next)
     },
     [],
   )
 
   const removeFavorite = useCallback((articleId: string) => {
-    setFavorites((prev) => {
-      const next = prev.filter((f) => f.id !== articleId)
-      saveFavorites(next)
-      return next
-    })
+    const current = getSnapshot()
+    setFavorites(current.filter((f) => f.id !== articleId))
   }, [])
 
   const getFavorite = useCallback(

--- a/qiita-ai/src/hooks/useKanban.ts
+++ b/qiita-ai/src/hooks/useKanban.ts
@@ -1,30 +1,50 @@
-import { useState, useCallback } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 import type { KanbanColumn } from '../types/kanban'
 import { DEFAULT_COLUMNS, COLUMNS_STORAGE_KEY } from '../types/kanban'
+import { loadJson, saveJson } from '../utils/storage'
 
-function loadColumns(): KanbanColumn[] {
-  try {
-    const raw = localStorage.getItem(COLUMNS_STORAGE_KEY)
-    return raw ? (JSON.parse(raw) as KanbanColumn[]) : DEFAULT_COLUMNS
-  } catch {
-    return DEFAULT_COLUMNS
+type Listener = () => void
+
+let cache: KanbanColumn[] | null = null
+const listeners = new Set<Listener>()
+
+function getSnapshot(): KanbanColumn[] {
+  if (cache === null) {
+    cache = loadJson<KanbanColumn[]>(COLUMNS_STORAGE_KEY, DEFAULT_COLUMNS)
+  }
+  return cache
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener)
+
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === COLUMNS_STORAGE_KEY) {
+      cache = null
+      listeners.forEach((l) => l())
+    }
+  }
+  window.addEventListener('storage', onStorage)
+
+  return () => {
+    listeners.delete(listener)
+    window.removeEventListener('storage', onStorage)
   }
 }
 
-function saveColumns(columns: KanbanColumn[]): void {
-  localStorage.setItem(COLUMNS_STORAGE_KEY, JSON.stringify(columns))
+function setColumns(next: KanbanColumn[]): void {
+  saveJson(COLUMNS_STORAGE_KEY, next)
+  cache = next
+  listeners.forEach((l) => l())
+}
+
+function updateColumns(updater: (prev: KanbanColumn[]) => KanbanColumn[]): void {
+  const next = updater(getSnapshot())
+  setColumns(next)
 }
 
 export function useKanban() {
-  const [columns, setColumns] = useState<KanbanColumn[]>(loadColumns)
-
-  const updateColumns = useCallback((updater: (prev: KanbanColumn[]) => KanbanColumn[]) => {
-    setColumns((prev) => {
-      const next = updater(prev)
-      saveColumns(next)
-      return next
-    })
-  }, [])
+  const columns = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 
   const addArticleToBoard = useCallback(
     (articleId: string) => {
@@ -36,7 +56,7 @@ export function useKanban() {
         )
       })
     },
-    [updateColumns],
+    [],
   )
 
   const removeArticleFromBoard = useCallback(
@@ -48,7 +68,7 @@ export function useKanban() {
         })),
       )
     },
-    [updateColumns],
+    [],
   )
 
   const moveArticle = useCallback(
@@ -72,7 +92,7 @@ export function useKanban() {
         }),
       )
     },
-    [updateColumns],
+    [],
   )
 
   const addColumn = useCallback(
@@ -80,7 +100,7 @@ export function useKanban() {
       const id = `custom-${Date.now()}`
       updateColumns((prev) => [...prev, { id, title, articleIds: [] }])
     },
-    [updateColumns],
+    [],
   )
 
   const renameColumn = useCallback(
@@ -89,7 +109,7 @@ export function useKanban() {
         prev.map((col) => (col.id === columnId ? { ...col, title } : col)),
       )
     },
-    [updateColumns],
+    [],
   )
 
   const deleteColumn = useCallback(
@@ -105,7 +125,7 @@ export function useKanban() {
           )
       })
     },
-    [updateColumns],
+    [],
   )
 
   const findColumnByArticleId = useCallback(

--- a/qiita-ai/src/utils/storage.ts
+++ b/qiita-ai/src/utils/storage.ts
@@ -1,0 +1,17 @@
+export function loadJson<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key)
+    if (!raw) return fallback
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
+}
+
+export function saveJson<T>(key: string, value: T): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    // Safari private browsing or quota exceeded — silently fail
+  }
+}


### PR DESCRIPTION
## Summary

- **キーワード検索バー**: ホーム画面にデバウンス付き検索バーを追加。記事タイトルの部分一致でクライアントサイドフィルタリング
- **記事共有ボタン**: 記事カードにURLコピーボタンを追加。コピー成功時にチェックマークでフィードバック表示
- **読書統計ウィジェット**: カンバンボードに各カラムの記事数と読了率プログレスバーを表示
- **localStorage永続化修正**: `useState` → `useSyncExternalStore` に書き換え、iPhone Safari でリロード時にお気に入りが消える問題を解消
- **API取得速度改善**: source=all 時にQiitaを先に表示しZennを後から追加する段階的フェッチに変更。Zennのデフォルトtopic数を5→3に削減

## Test plan

- [x] `npm run build` 成功
- [x] ユニットテスト 93件 全パス
- [ ] iPhone Safari でお気に入り追加後にリロードし、データが保持されることを確認
- [ ] ホーム画面でキーワード検索が動作し、クリアボタンで解除されることを確認
- [ ] 記事カードのリンクアイコンクリックでURLがコピーされることを確認
- [ ] カンバンボードで読書統計の読了率が正しく表示されることを確認
- [ ] source=all で Qiita記事が先に表示され、Zenn記事が後から追加されることを確認

https://claude.ai/code/session_01AFizioro56y8Cwor9iuDAA