### PR TITLE
feat: Qiita記事アプリに機能追加・永続化修正・取得速度改善

### DIFF
--- a/qiita-ai/src/hooks/useArticles.test.ts
+++ b/qiita-ai/src/hooks/useArticles.test.ts
@@ -24,6 +24,7 @@ const mockZennArticle: Article = {
 
 describe('useArticles', () => {
   beforeEach(() => {
+    localStorage.clear()
     vi.spyOn(qiitaApi, 'fetchQiitaArticles')
     vi.spyOn(zennApi, 'fetchZennArticles')
   })

--- a/qiita-ai/src/hooks/useArticles.ts
+++ b/qiita-ai/src/hooks/useArticles.ts
@@ -3,6 +3,7 @@ import type { Article, SourceFilter } from '../types/article'
 import type { SortOrder, DateRange } from '../types/qiita'
 import { fetchQiitaArticles } from '../utils/qiitaApi'
 import { fetchZennArticles } from '../utils/zennApi'
+import { loadCache, saveCache } from '../utils/storage'
 
 interface UseArticlesParams {
   tags: string[]
@@ -24,6 +25,7 @@ type State = UseArticlesResult
 
 type Action =
   | { type: 'loading' }
+  | { type: 'cache'; articles: Article[]; totalCount: number }
   | { type: 'success'; articles: Article[]; totalCount: number }
   | { type: 'partial'; articles: Article[]; totalCount: number }
   | { type: 'append'; articles: Article[]; sort: SortOrder }
@@ -41,6 +43,9 @@ function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'loading':
       return { ...state, loading: true, error: null }
+    case 'cache':
+      // キャッシュから復元: loadingは継続（裏でフェッチ中）
+      return { articles: action.articles, totalCount: action.totalCount, loading: true, error: null }
     case 'success':
       return { articles: action.articles, totalCount: action.totalCount, loading: false, error: null }
     case 'partial':
@@ -50,8 +55,21 @@ function reducer(state: State, action: Action): State {
       return { ...state, articles: merged }
     }
     case 'error':
+      // キャッシュ記事がある場合はエラーでも記事を維持
+      if (state.articles.length > 0) {
+        return { ...state, loading: false, error: null }
+      }
       return { ...state, loading: false, error: action.message }
   }
+}
+
+function cacheKey(tagsKey: string, sort: string, page: number, source: string, dateRange: string): string {
+  return `qiita-ai-articles-${source}-${tagsKey}-${sort}-${page}-${dateRange}`
+}
+
+interface CachedResult {
+  articles: Article[]
+  totalCount: number
 }
 
 const initialState: State = { articles: [], loading: true, error: null, totalCount: 0 }
@@ -64,32 +82,49 @@ export function useArticles({ tags, sort, page, source, dateRange, retryCount = 
   useEffect(() => {
     let cancelled = false
 
-    dispatch({ type: 'loading' })
+    const key = cacheKey(tagsKey, sort, page, source, dateRange)
+
+    // ステップ1: キャッシュがあれば即座に表示
+    const cached = loadCache<CachedResult>(key)
+    if (cached) {
+      dispatch({ type: 'cache', articles: cached.articles, totalCount: cached.totalCount })
+    } else {
+      dispatch({ type: 'loading' })
+    }
+
+    // ステップ2: 裏でAPI取得して更新 + キャッシュ保存
+    function saveAndDispatch(articles: Article[], totalCount: number): void {
+      if (cancelled) return
+      saveCache(key, { articles, totalCount })
+      dispatch({ type: 'success', articles, totalCount })
+    }
 
     if (source === 'qiita') {
       fetchQiitaArticles({ tags, sort, page, dateRange })
-        .then(({ articles, totalCount }) => {
-          if (!cancelled) dispatch({ type: 'success', articles, totalCount })
-        })
+        .then(({ articles, totalCount }) => saveAndDispatch(articles, totalCount))
         .catch((err: Error) => {
           if (!cancelled) dispatch({ type: 'error', message: err.message })
         })
     } else if (source === 'zenn') {
       fetchZennArticles({ tags, sort, page })
-        .then(({ articles, totalCount }) => {
-          if (!cancelled) dispatch({ type: 'success', articles, totalCount })
-        })
+        .then(({ articles, totalCount }) => saveAndDispatch(articles, totalCount))
         .catch((err: Error) => {
           if (!cancelled) dispatch({ type: 'error', message: err.message })
         })
     } else {
-      // 'all': Qiitaを先に表示、Zennを後から追加（段階的フェッチ）
+      // 'all': Qiitaを先に表示、Zennを後から追加
       let qiitaFailed = false
       let zennFailed = false
+      let allArticles: Article[] = []
+      let qiitaTotalCount = 0
 
       const qiitaPromise = fetchQiitaArticles({ tags, sort, page, dateRange })
         .then(({ articles, totalCount }) => {
-          if (!cancelled) dispatch({ type: 'partial', articles, totalCount })
+          if (!cancelled) {
+            allArticles = articles
+            qiitaTotalCount = totalCount
+            dispatch({ type: 'partial', articles, totalCount })
+          }
         })
         .catch((err: Error) => {
           qiitaFailed = true
@@ -98,7 +133,10 @@ export function useArticles({ tags, sort, page, source, dateRange, retryCount = 
 
       const zennPromise = fetchZennArticles({ tags, sort, page })
         .then(({ articles }) => {
-          if (!cancelled) dispatch({ type: 'append', articles, sort })
+          if (!cancelled) {
+            allArticles = sortArticles([...allArticles, ...articles], sort)
+            dispatch({ type: 'append', articles, sort })
+          }
         })
         .catch((err: Error) => {
           zennFailed = true
@@ -106,9 +144,13 @@ export function useArticles({ tags, sort, page, source, dateRange, retryCount = 
         })
 
       Promise.all([qiitaPromise, zennPromise]).then(([qiitaErr]) => {
-        if (!cancelled && qiitaFailed && zennFailed) {
+        if (cancelled) return
+        if (qiitaFailed && zennFailed) {
           const msg = qiitaErr instanceof Error ? qiitaErr.message : '記事の取得に失敗しました'
           dispatch({ type: 'error', message: msg })
+        } else {
+          // 成功分をキャッシュ
+          saveCache(key, { articles: allArticles, totalCount: qiitaTotalCount })
         }
       })
     }

--- a/qiita-ai/src/hooks/useFavorites.ts
+++ b/qiita-ai/src/hooks/useFavorites.ts
@@ -33,10 +33,12 @@ function subscribe(listener: Listener): () => void {
   }
 }
 
-function setFavorites(next: FavoriteArticle[]): void {
-  saveJson(FAVORITES_STORAGE_KEY, next)
-  cache = next
-  listeners.forEach((l) => l())
+function writeFavorites(next: FavoriteArticle[]): boolean {
+  const ok = saveJson(FAVORITES_STORAGE_KEY, next)
+  if (ok) {
+    cache = next
+  }
+  return ok
 }
 
 export function useFavorites() {
@@ -54,14 +56,14 @@ export function useFavorites() {
       const next = exists
         ? current.filter((f) => f.id !== article.id)
         : [...current, { ...article, favorited_at: new Date().toISOString() }]
-      setFavorites(next)
+      writeFavorites(next)
     },
     [],
   )
 
   const removeFavorite = useCallback((articleId: string) => {
     const current = getSnapshot()
-    setFavorites(current.filter((f) => f.id !== articleId))
+    writeFavorites(current.filter((f) => f.id !== articleId))
   }, [])
 
   const getFavorite = useCallback(

--- a/qiita-ai/src/hooks/useKanban.ts
+++ b/qiita-ai/src/hooks/useKanban.ts
@@ -32,15 +32,16 @@ function subscribe(listener: Listener): () => void {
   }
 }
 
-function setColumns(next: KanbanColumn[]): void {
-  saveJson(COLUMNS_STORAGE_KEY, next)
-  cache = next
-  listeners.forEach((l) => l())
+function writeColumns(next: KanbanColumn[]): void {
+  const ok = saveJson(COLUMNS_STORAGE_KEY, next)
+  if (ok) {
+    cache = next
+  }
 }
 
 function updateColumns(updater: (prev: KanbanColumn[]) => KanbanColumn[]): void {
   const next = updater(getSnapshot())
-  setColumns(next)
+  writeColumns(next)
 }
 
 export function useKanban() {

--- a/qiita-ai/src/utils/storage.ts
+++ b/qiita-ai/src/utils/storage.ts
@@ -8,10 +8,47 @@ export function loadJson<T>(key: string, fallback: T): T {
   }
 }
 
-export function saveJson<T>(key: string, value: T): void {
+export function saveJson<T>(key: string, value: T): boolean {
   try {
-    localStorage.setItem(key, JSON.stringify(value))
+    const json = JSON.stringify(value)
+    localStorage.setItem(key, json)
+    // 書き込み検証: 読み戻して一致するか確認
+    const verify = localStorage.getItem(key)
+    if (verify !== json) return false
+    // 同一タブの他コンポーネントに変更を通知
+    window.dispatchEvent(
+      new StorageEvent('storage', { key, newValue: json })
+    )
+    return true
   } catch {
-    // Safari private browsing or quota exceeded — silently fail
+    return false
+  }
+}
+
+interface CacheEntry<T> {
+  data: T
+  timestamp: number
+}
+
+const CACHE_TTL = 5 * 60 * 1000 // 5分
+
+export function loadCache<T>(key: string): T | null {
+  try {
+    const raw = localStorage.getItem(key)
+    if (!raw) return null
+    const entry = JSON.parse(raw) as CacheEntry<T>
+    if (Date.now() - entry.timestamp > CACHE_TTL) return null
+    return entry.data
+  } catch {
+    return null
+  }
+}
+
+export function saveCache<T>(key: string, data: T): void {
+  try {
+    const entry: CacheEntry<T> = { data, timestamp: Date.now() }
+    localStorage.setItem(key, JSON.stringify(entry))
+  } catch {
+    // キャッシュ書き込み失敗は無視（重要データではない）
   }
 }


### PR DESCRIPTION
## Summary

- **キーワード検索バー**: ホーム画面にデバウンス付き検索バーを追加（タイトル部分一致フィルタリング）
- **記事共有ボタン**: 記事カードにURLコピーボタンを追加（コピー成功時チェックマーク表示）
- **読書統計ウィジェット**: カンバンボードに各カラムの記事数と読了率プログレスバーを表示
- **localStorage永続化修正**: `useSyncExternalStore`で確実に同期、書き込み後の読み戻し検証、同一タブ内StorageEvent dispatch
- **記事キャッシュ（stale-while-revalidate）**: API取得結果をlocalStorageにキャッシュ（TTL 5分）、リロード時に即座に記事を表示し裏でAPI更新
- **API取得速度改善**: source=all時にQiitaを先に表示しZennを後から追加する段階的フェッチ、ZennデフォルトTopic数を5→3に削減

## Test plan

- [x] `npm run build` 成功
- [x] ユニットテスト 93件 全パス
- [ ] iPhone Safariでお気に入り追加後にリロードし、データが保持されることを確認
- [ ] リロード時にキャッシュから記事が即座に表示されることを確認
- [ ] ホーム画面でキーワード検索が動作し、クリアボタンで解除されることを確認
- [ ] 記事カードのリンクアイコンクリックでURLがコピーされることを確認
- [ ] カンバンボードで読書統計の読了率が正しく表示されることを確認

https://claude.ai/code/session_01AFizioro56y8Cwor9iuDAA