### PR TITLE
fix: IndexedDBによる永続化でiOS Safariのストレージ削除に対応

### DIFF
--- a/qiita-ai/src/hooks/useFavorites.ts
+++ b/qiita-ai/src/hooks/useFavorites.ts
@@ -1,13 +1,17 @@
-import { useCallback, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
 import type { Article } from '../types/article'
 import type { FavoriteArticle } from '../types/kanban'
 import { FAVORITES_STORAGE_KEY } from '../types/kanban'
-import { loadJson, saveJson } from '../utils/storage'
+import { loadJson, saveJson, persistJson, restoreFromIdb } from '../utils/storage'
 
 type Listener = () => void
 
 let cache: FavoriteArticle[] | null = null
 const listeners = new Set<Listener>()
+
+function notify(): void {
+  listeners.forEach((l) => l())
+}
 
 function getSnapshot(): FavoriteArticle[] {
   if (cache === null) {
@@ -22,7 +26,7 @@ function subscribe(listener: Listener): () => void {
   const onStorage = (e: StorageEvent) => {
     if (e.key === FAVORITES_STORAGE_KEY) {
       cache = null
-      listeners.forEach((l) => l())
+      notify()
     }
   }
   window.addEventListener('storage', onStorage)
@@ -33,16 +37,30 @@ function subscribe(listener: Listener): () => void {
   }
 }
 
-function writeFavorites(next: FavoriteArticle[]): boolean {
-  const ok = saveJson(FAVORITES_STORAGE_KEY, next)
-  if (ok) {
-    cache = next
-  }
-  return ok
+function writeFavorites(next: FavoriteArticle[]): void {
+  saveJson(FAVORITES_STORAGE_KEY, next)
+  cache = next
+  notify()
+  // IndexedDB にも非同期で永続化
+  persistJson(FAVORITES_STORAGE_KEY, next)
 }
 
 export function useFavorites() {
   const favorites = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  // 起動時に IndexedDB から復元 (localStorage が消えていた場合)
+  useEffect(() => {
+    let cancelled = false
+    restoreFromIdb<FavoriteArticle[]>(FAVORITES_STORAGE_KEY, []).then((restored) => {
+      if (cancelled) return
+      if (restored.length > 0 && getSnapshot().length === 0) {
+        cache = restored
+        saveJson(FAVORITES_STORAGE_KEY, restored)
+        notify()
+      }
+    })
+    return () => { cancelled = true }
+  }, [])
 
   const isFavorite = useCallback(
     (articleId: string) => favorites.some((f) => f.id === articleId),

--- a/qiita-ai/src/hooks/useKanban.ts
+++ b/qiita-ai/src/hooks/useKanban.ts
@@ -1,12 +1,16 @@
-import { useCallback, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
 import type { KanbanColumn } from '../types/kanban'
 import { DEFAULT_COLUMNS, COLUMNS_STORAGE_KEY } from '../types/kanban'
-import { loadJson, saveJson } from '../utils/storage'
+import { loadJson, saveJson, persistJson, restoreFromIdb } from '../utils/storage'
 
 type Listener = () => void
 
 let cache: KanbanColumn[] | null = null
 const listeners = new Set<Listener>()
+
+function notify(): void {
+  listeners.forEach((l) => l())
+}
 
 function getSnapshot(): KanbanColumn[] {
   if (cache === null) {
@@ -21,7 +25,7 @@ function subscribe(listener: Listener): () => void {
   const onStorage = (e: StorageEvent) => {
     if (e.key === COLUMNS_STORAGE_KEY) {
       cache = null
-      listeners.forEach((l) => l())
+      notify()
     }
   }
   window.addEventListener('storage', onStorage)
@@ -33,10 +37,10 @@ function subscribe(listener: Listener): () => void {
 }
 
 function writeColumns(next: KanbanColumn[]): void {
-  const ok = saveJson(COLUMNS_STORAGE_KEY, next)
-  if (ok) {
-    cache = next
-  }
+  saveJson(COLUMNS_STORAGE_KEY, next)
+  cache = next
+  notify()
+  persistJson(COLUMNS_STORAGE_KEY, next)
 }
 
 function updateColumns(updater: (prev: KanbanColumn[]) => KanbanColumn[]): void {
@@ -46,6 +50,23 @@ function updateColumns(updater: (prev: KanbanColumn[]) => KanbanColumn[]): void 
 
 export function useKanban() {
   const columns = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  // 起動時に IndexedDB から復元
+  useEffect(() => {
+    let cancelled = false
+    restoreFromIdb<KanbanColumn[]>(COLUMNS_STORAGE_KEY, DEFAULT_COLUMNS).then((restored) => {
+      if (cancelled) return
+      const current = getSnapshot()
+      const currentHasData = current.some((col) => col.articleIds.length > 0)
+      const restoredHasData = restored.some((col) => col.articleIds.length > 0)
+      if (!currentHasData && restoredHasData) {
+        cache = restored
+        saveJson(COLUMNS_STORAGE_KEY, restored)
+        notify()
+      }
+    })
+    return () => { cancelled = true }
+  }, [])
 
   const addArticleToBoard = useCallback(
     (articleId: string) => {

--- a/qiita-ai/src/utils/idb.ts
+++ b/qiita-ai/src/utils/idb.ts
@@ -1,0 +1,37 @@
+const DB_NAME = 'qiita-ai-db'
+const DB_VERSION = 1
+const STORE_NAME = 'keyval'
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME)
+      }
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+export async function idbGet<T>(key: string): Promise<T | undefined> {
+  const db = await openDB()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly')
+    const req = tx.objectStore(STORE_NAME).get(key)
+    req.onsuccess = () => resolve(req.result as T | undefined)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+export async function idbSet<T>(key: string, value: T): Promise<void> {
+  const db = await openDB()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    tx.objectStore(STORE_NAME).put(value, key)
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+  })
+}

--- a/qiita-ai/src/utils/storage.ts
+++ b/qiita-ai/src/utils/storage.ts
@@ -1,3 +1,7 @@
+import { idbGet, idbSet } from './idb'
+
+// ── localStorage (同期) ──────────────────────────
+
 export function loadJson<T>(key: string, fallback: T): T {
   try {
     const raw = localStorage.getItem(key)
@@ -12,10 +16,8 @@ export function saveJson<T>(key: string, value: T): boolean {
   try {
     const json = JSON.stringify(value)
     localStorage.setItem(key, json)
-    // 書き込み検証: 読み戻して一致するか確認
     const verify = localStorage.getItem(key)
     if (verify !== json) return false
-    // 同一タブの他コンポーネントに変更を通知
     window.dispatchEvent(
       new StorageEvent('storage', { key, newValue: json })
     )
@@ -25,12 +27,52 @@ export function saveJson<T>(key: string, value: T): boolean {
   }
 }
 
+// ── IndexedDB (非同期・永続) ─────────────────────
+
+/** IndexedDBに保存 (localStorage にも同時書き込み) */
+export async function persistJson<T>(key: string, value: T): Promise<void> {
+  saveJson(key, value)
+  try {
+    await idbSet(key, value)
+  } catch {
+    // IndexedDB非対応でも localStorage に書き込み済み
+  }
+}
+
+/**
+ * 起動時に IndexedDB からデータを復元する。
+ * localStorage が空で IndexedDB にデータがある場合、localStorage に書き戻す。
+ * 戻り値: 復元されたデータ、または fallback。
+ */
+export async function restoreFromIdb<T>(key: string, fallback: T): Promise<T> {
+  const lsValue = loadJson<T>(key, undefined as unknown as T)
+
+  try {
+    const idbValue = await idbGet<T>(key)
+
+    if (idbValue !== undefined) {
+      if (lsValue === undefined || lsValue === null) {
+        // localStorage が消えている → IndexedDB から復元
+        saveJson(key, idbValue)
+      }
+      return idbValue
+    }
+  } catch {
+    // IndexedDB非対応
+  }
+
+  // IndexedDB にデータがない場合は localStorage の値を使う
+  return lsValue ?? fallback
+}
+
+// ── 記事キャッシュ (localStorage のみ、消えても問題ない) ─
+
 interface CacheEntry<T> {
   data: T
   timestamp: number
 }
 
-const CACHE_TTL = 5 * 60 * 1000 // 5分
+const CACHE_TTL = 5 * 60 * 1000
 
 export function loadCache<T>(key: string): T | null {
   try {
@@ -49,6 +91,6 @@ export function saveCache<T>(key: string, data: T): void {
     const entry: CacheEntry<T> = { data, timestamp: Date.now() }
     localStorage.setItem(key, JSON.stringify(entry))
   } catch {
-    // キャッシュ書き込み失敗は無視（重要データではない）
+    // キャッシュ書き込み失敗は無視
   }
 }


### PR DESCRIPTION
## Summary

- IndexedDB + localStorage の二重書き込みにより、iOS SafariがバックグラウンドでlocalStorageを削除してもデータを復元可能に
- 起動時にIndexedDBからlocalStorageへの自動復元処理を追加
- IndexedDBラッパー (`idb.ts`) を新規追加

## Test plan

- [x] `npm run build` 成功
- [x] ユニットテスト 93件 全パス
- [ ] iPhone Safariでお気に入り追加 → Safariを完全終了 → 再起動してデータが残ることを確認
- [ ] Safari Private Browsingでもエラーなく動作することを確認

https://claude.ai/code/session_01AFizioro56y8Cwor9iuDAA